### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This solution provides a simple implementation of a Trie data structure for stri
 - Retrieve all words
 
 ## Running the Solution
-1. Open the solution in Visual Studio or any .NET IDE.
-2. Build and run the `TrieDictionary` project.
+1. Open the solution in Visual Studio or any .NET IDE
+2. Build and run the `TrieDictionary` project
 
 ## Testing
-Run the tests in `TrieDictionary.Tests` using your preferred test runner (e.g., Visual Studio Test Explorer).
+Run the tests in `TrieDictionary.Tests` using your preferred test runner (e.g., Visual Studio Test Explorer)


### PR DESCRIPTION
Fixes #2

Remove redundant full-stops from the `README.md`.

* Remove full-stops at the end of each step in the "Running the Solution" section.
* Remove the full-stop at the end of the sentence in the "Testing" section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tvergilio/trie/pull/3?shareId=9100f179-c33e-49cf-a926-91d5b053a17f).